### PR TITLE
티켓 링크 서비스 예외처리, 시큐리티 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	testCompileOnly 'org.projectlombok:lombok:1.18.32'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.32'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
 	testImplementation 'org.springframework.security:spring-security-test'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/beyond/ticketLink/TicketLinkApplication.java
+++ b/src/main/java/com/beyond/ticketLink/TicketLinkApplication.java
@@ -2,7 +2,9 @@ package com.beyond.ticketLink;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
+@EnableWebSecurity(debug = true)
 @SpringBootApplication
 public class TicketLinkApplication {
 

--- a/src/main/java/com/beyond/ticketLink/common/advice/TicketLinkControllerAdvice.java
+++ b/src/main/java/com/beyond/ticketLink/common/advice/TicketLinkControllerAdvice.java
@@ -3,6 +3,7 @@ package com.beyond.ticketLink.common.advice;
 import com.beyond.ticketLink.common.exception.MessageType;
 import com.beyond.ticketLink.common.exception.TicketLinkException;
 import com.beyond.ticketLink.common.view.ApiErrorView;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -23,7 +24,7 @@ import java.util.Collections;
 public class TicketLinkControllerAdvice extends ResponseEntityExceptionHandler {
 
 
-    @ExceptionHandler(TicketLinkException.class)
+    @ExceptionHandler(ClientAbortException.class)
     public ResponseEntity<?> clientAbortException() {
         return new ResponseEntity<>(new ApiErrorView(Collections.singletonList(MessageType.INTERNAL_SERVER_ERROR)),
                 HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/beyond/ticketLink/common/advice/TicketLinkControllerAdvice.java
+++ b/src/main/java/com/beyond/ticketLink/common/advice/TicketLinkControllerAdvice.java
@@ -1,0 +1,66 @@
+package com.beyond.ticketLink.common.advice;
+
+import com.beyond.ticketLink.common.exception.MessageType;
+import com.beyond.ticketLink.common.exception.TicketLinkException;
+import com.beyond.ticketLink.common.view.ApiErrorView;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Collections;
+
+@RestControllerAdvice
+public class TicketLinkControllerAdvice extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler(TicketLinkException.class)
+    public ResponseEntity<?> clientAbortException() {
+        return new ResponseEntity<>(new ApiErrorView(Collections.singletonList(MessageType.INTERNAL_SERVER_ERROR)),
+                HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(TicketLinkException.class)
+    public ResponseEntity<?> onMessageException(TicketLinkException ex) {
+        return new ResponseEntity<>(new ApiErrorView(ex), ex.getStatus());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.BAD_REQUEST, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.BAD_REQUEST, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.BAD_REQUEST, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.BAD_REQUEST, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.BAD_REQUEST, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.INTERNAL_SERVER_ERROR, ex.getMessage()), statusCode);
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/common/config/TicketLinkSecurityConfig.java
+++ b/src/main/java/com/beyond/ticketLink/common/config/TicketLinkSecurityConfig.java
@@ -1,0 +1,41 @@
+package com.beyond.ticketLink.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+public class TicketLinkSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
+        http.httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET","POST", "PUT", "PATCH"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
+
+}

--- a/src/main/java/com/beyond/ticketLink/common/exception/MessageType.java
+++ b/src/main/java/com/beyond/ticketLink/common/exception/MessageType.java
@@ -1,0 +1,23 @@
+package com.beyond.ticketLink.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MessageType {
+
+    // common errors
+    BAD_REQUEST ("Check API request URL protocol, parameter, etc. for errors", HttpStatus.BAD_REQUEST),
+    NOT_FOUND ("No data was found for the server. Please refer  to parameter description.", HttpStatus.NOT_FOUND),
+    INTERNAL_SERVER_ERROR ("An error occurred inside the server.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    // add additional errors
+
+    private final String message;
+    private final HttpStatus status;
+
+    MessageType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/common/exception/TicketLinkException.java
+++ b/src/main/java/com/beyond/ticketLink/common/exception/TicketLinkException.java
@@ -1,0 +1,16 @@
+package com.beyond.ticketLink.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class TicketLinkException extends RuntimeException {
+    private final HttpStatus status;
+    private final String type;
+
+    public TicketLinkException(MessageType message) {
+        super(message.getMessage());
+        this.status = message.getStatus();
+        this.type = message.name();
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/common/view/ApiErrorView.java
+++ b/src/main/java/com/beyond/ticketLink/common/view/ApiErrorView.java
@@ -1,0 +1,59 @@
+package com.beyond.ticketLink.common.view;
+
+import com.beyond.ticketLink.common.exception.MessageType;
+import com.beyond.ticketLink.common.exception.TicketLinkException;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@ToString
+public class ApiErrorView {
+    private final List<Error> errors;
+
+    public ApiErrorView(List<MessageType> messageTypes) {
+        this.errors = messageTypes.stream().map(Error::errorWithMessageType).collect(Collectors.toList());
+    }
+
+    public ApiErrorView(TicketLinkException exception) {
+        this.errors = Collections.singletonList(Error.errorWithException(exception));
+    }
+
+    public ApiErrorView(MessageType messageType, String message) {
+        this.errors = Collections.singletonList(Error.errorWithMessageTypeAndMessage(messageType, message));
+    }
+
+    @Getter
+    @ToString
+    public static class Error {
+        private final String errorType;
+        private final String errorMessage;
+
+        public static Error errorWithMessageType(MessageType messageType) {
+            return new Error(messageType.name(), messageType.getMessage());
+        }
+
+        public static Error errorWithMessageTypeAndMessage(MessageType messageType, String message) {
+            return new Error(messageType.name(), message);
+        }
+
+        public static Error errorWithException(TicketLinkException ticketLinkException) {
+            return new Error(ticketLinkException);
+        }
+
+        private Error(String errorType, String errorMessage) {
+            this.errorType = errorType;
+            this.errorMessage = errorMessage;
+        }
+
+        private Error(TicketLinkException ticketLinkException) {
+            this.errorType = ObjectUtils.isEmpty(ticketLinkException.getType()) ? ticketLinkException.getStatus().getReasonPhrase() :
+                    ticketLinkException.getType();
+            this.errorMessage = ticketLinkException.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/common/view/ApiResponseView.java
+++ b/src/main/java/com/beyond/ticketLink/common/view/ApiResponseView.java
@@ -1,0 +1,21 @@
+package com.beyond.ticketLink.common.view;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * To unify the format of views returned by the controller
+ * wrap the view returned by the controller
+ * @param <T> any type of view
+ */
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponseView<T> {
+    private final T data;
+
+    public ApiResponseView(T data) {
+        this.data = data;
+    }
+}


### PR DESCRIPTION
MessageType
- 티켓 링크 어플리케이션 내에서 발생하는 예외에 대한 메세지들

TicketLinkException
- 런타임 에러를 상속 받은 커스텀 에러

ApiErrorView
- 에러가 발생했을 때 클라이언트에 전달되는 뷰

TicketLinkControllerAdvice
- 티켓링크 서비스 내 모든 컨트롤러에서 throw된 에러를 처리하는 어드바이스

ApiResponseView
- 티켓링크 서비스에서 클라이언트로 전달되는 view의 형식을 통일하는 wrapper view
