### PR TITLE
유저 생성, 아이디 조회 서비스 로직 추가

### DIFF
--- a/src/main/java/com/beyond/ticketLink/common/config/TicketLinkSecurityConfig.java
+++ b/src/main/java/com/beyond/ticketLink/common/config/TicketLinkSecurityConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -35,6 +37,11 @@ public class TicketLinkSecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
 
         return source;
+    }
+
+    @Bean
+    public PasswordEncoder getBCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
 

--- a/src/main/java/com/beyond/ticketLink/common/exception/MessageType.java
+++ b/src/main/java/com/beyond/ticketLink/common/exception/MessageType.java
@@ -7,11 +7,15 @@ import org.springframework.http.HttpStatus;
 public enum MessageType {
 
     // common errors
-    BAD_REQUEST ("Check API request URL protocol, parameter, etc. for errors", HttpStatus.BAD_REQUEST),
-    NOT_FOUND ("No data was found for the server. Please refer  to parameter description.", HttpStatus.NOT_FOUND),
-    INTERNAL_SERVER_ERROR ("An error occurred inside the server.", HttpStatus.INTERNAL_SERVER_ERROR);
+    BAD_REQUEST("Check API request URL protocol, parameter, etc. for errors", HttpStatus.BAD_REQUEST),
+    NOT_FOUND("No data was found for the server. Please refer  to parameter description.", HttpStatus.NOT_FOUND),
+    INTERNAL_SERVER_ERROR("An error occurred inside the server.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // add additional errors
+    USER_NOT_FOUND("The user matching the ID doesn't exist.", HttpStatus.NOT_FOUND),
+    DUPLICATE_USER_ID("Duplicate id.", HttpStatus.BAD_REQUEST),
+    USER_ROLE_NOT_FOUND("The role matching the name doesn't exist.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ;
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/beyond/ticketLink/user/application/domain/TicketLinkUserDetails.java
+++ b/src/main/java/com/beyond/ticketLink/user/application/domain/TicketLinkUserDetails.java
@@ -1,0 +1,47 @@
+package com.beyond.ticketLink.user.application.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class TicketLinkUserDetails implements UserDetails {
+
+    private String userNo;
+    private String id;
+    private String pw;
+    private String name;
+    private String email;
+    private char useYn;
+    private String role;
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return this.pw;
+    }
+
+    // 아이디 반환
+    @Override
+    public String getUsername() {
+        return this.id;
+    }
+
+    // 계정 활성화 여부
+    @Override
+    public boolean isEnabled() {
+        return useYn == 'Y';
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/user/application/domain/UserRole.java
+++ b/src/main/java/com/beyond/ticketLink/user/application/domain/UserRole.java
@@ -1,0 +1,13 @@
+package com.beyond.ticketLink.user.application.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class UserRole {
+    private final Long id;
+    private final String name;
+}

--- a/src/main/java/com/beyond/ticketLink/user/application/service/UserService.java
+++ b/src/main/java/com/beyond/ticketLink/user/application/service/UserService.java
@@ -1,0 +1,11 @@
+package com.beyond.ticketLink.user.application.service;
+
+import com.beyond.ticketLink.user.ui.requestbody.UserCreateRequest;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface UserService extends UserDetailsService {
+
+    void register(UserCreateRequest request);
+
+    void throwErrorWithDuplicateId(String id);
+}

--- a/src/main/java/com/beyond/ticketLink/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/beyond/ticketLink/user/application/service/UserServiceImpl.java
@@ -1,0 +1,80 @@
+package com.beyond.ticketLink.user.application.service;
+
+import com.beyond.ticketLink.common.exception.MessageType;
+import com.beyond.ticketLink.common.exception.TicketLinkException;
+import com.beyond.ticketLink.user.application.domain.UserRole;
+import com.beyond.ticketLink.user.persistence.dto.UserCreateDto;
+import com.beyond.ticketLink.user.persistence.repository.UserRepository;
+import com.beyond.ticketLink.user.persistence.repository.UserRoleRepository;
+import com.beyond.ticketLink.user.ui.requestbody.UserCreateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    private final UserRoleRepository userRoleRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private static final char ENABLE_USER = 'Y';
+    private static final String ROLE_USER = "일반사용자";
+
+    @Override
+    @Transactional
+    public void register(UserCreateRequest request) {
+
+        // 아이디가 중복 되었을 경우 404_Error throw
+        if (userRepository.findUserById(request.id()).isPresent()) {
+            throw new TicketLinkException(MessageType.DUPLICATE_USER_ID);
+        }
+
+        // db에 user role 설정이 잘못 되어 있을 경우 500_Error throw
+        UserRole userRole = userRoleRepository.findByRoleName(ROLE_USER)
+                .orElseThrow(() -> new TicketLinkException(MessageType.USER_ROLE_NOT_FOUND));
+
+
+        // 패스워드 암호화
+        String encryptedPassword = encryptPassword(request);
+
+        // 유저 저장
+        userRepository.save(
+                UserCreateDto.builder()
+                        .id(request.id())
+                        .pw(encryptedPassword)
+                        .name(request.name())
+                        .email(request.email())
+                        .useYn(ENABLE_USER)
+                        .roleNo(userRole.getId())
+                        .build()
+        );
+    }
+
+    @Override
+    public void throwErrorWithDuplicateId(String id) {
+
+        if (userRepository.findUserById(id).isPresent()) {
+            throw new TicketLinkException(MessageType.DUPLICATE_USER_ID);
+        }
+
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findUserById(username)
+                .orElseThrow(() -> new UsernameNotFoundException(MessageType.USER_NOT_FOUND.getMessage()));
+    }
+
+    private String encryptPassword(UserCreateRequest request) {
+        return passwordEncoder.encode(request.pw());
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/user/persistence/dto/UserCreateDto.java
+++ b/src/main/java/com/beyond/ticketLink/user/persistence/dto/UserCreateDto.java
@@ -1,0 +1,17 @@
+package com.beyond.ticketLink.user.persistence.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class UserCreateDto {
+    private final String id;
+    private final String pw;
+    private final String name;
+    private final String email;
+    private final char useYn;
+    private final Long roleNo;
+}

--- a/src/main/java/com/beyond/ticketLink/user/persistence/mapper/UserMapper.java
+++ b/src/main/java/com/beyond/ticketLink/user/persistence/mapper/UserMapper.java
@@ -1,0 +1,15 @@
+package com.beyond.ticketLink.user.persistence.mapper;
+
+import com.beyond.ticketLink.user.application.domain.TicketLinkUserDetails;
+import com.beyond.ticketLink.user.persistence.dto.UserCreateDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface UserMapper {
+
+    Optional<TicketLinkUserDetails> findUserById(String id);
+
+    void save(UserCreateDto user);
+}

--- a/src/main/java/com/beyond/ticketLink/user/persistence/mapper/UserRoleMapper.java
+++ b/src/main/java/com/beyond/ticketLink/user/persistence/mapper/UserRoleMapper.java
@@ -1,0 +1,11 @@
+package com.beyond.ticketLink.user.persistence.mapper;
+
+import com.beyond.ticketLink.user.application.domain.UserRole;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface UserRoleMapper {
+    Optional<UserRole> findByRoleName(String name);
+}

--- a/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.beyond.ticketLink.user.persistence.repository;
+
+import com.beyond.ticketLink.user.application.domain.TicketLinkUserDetails;
+import com.beyond.ticketLink.user.persistence.dto.UserCreateDto;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    Optional<TicketLinkUserDetails> findUserById(String id);
+
+    void save(UserCreateDto user);
+
+}

--- a/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.beyond.ticketLink.user.persistence.repository;
+
+import com.beyond.ticketLink.user.application.domain.TicketLinkUserDetails;
+import com.beyond.ticketLink.user.persistence.dto.UserCreateDto;
+import com.beyond.ticketLink.user.persistence.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserMapper mapper;
+
+    @Override
+    public Optional<TicketLinkUserDetails> findUserById(String id) {
+        return mapper.findUserById(id);
+    }
+
+    @Override
+    public void save(UserCreateDto user) {
+        mapper.save(user);
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRoleRepository.java
+++ b/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRoleRepository.java
@@ -1,0 +1,9 @@
+package com.beyond.ticketLink.user.persistence.repository;
+
+import com.beyond.ticketLink.user.application.domain.UserRole;
+
+import java.util.Optional;
+
+public interface UserRoleRepository {
+    Optional<UserRole> findByRoleName(String name);
+}

--- a/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRoleRepositoryImpl.java
+++ b/src/main/java/com/beyond/ticketLink/user/persistence/repository/UserRoleRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.beyond.ticketLink.user.persistence.repository;
+
+import com.beyond.ticketLink.user.application.domain.UserRole;
+import com.beyond.ticketLink.user.persistence.mapper.UserRoleMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRoleRepositoryImpl implements UserRoleRepository{
+    private final UserRoleMapper mapper;
+
+    @Override
+    public Optional<UserRole> findByRoleName(String name) {
+        return mapper.findByRoleName(name);
+    }
+}

--- a/src/main/java/com/beyond/ticketLink/user/ui/requestbody/UserCreateRequest.java
+++ b/src/main/java/com/beyond/ticketLink/user/ui/requestbody/UserCreateRequest.java
@@ -1,0 +1,24 @@
+package com.beyond.ticketLink.user.ui.requestbody;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+
+public record UserCreateRequest(
+        @NotEmpty
+        @Min(value = 6)
+        @Max(value = 20)
+        String id,
+
+        @NotEmpty
+        @Min(value = 8)
+        @Max(value = 12)
+        String pw,
+
+        @NotEmpty
+        String name,
+
+        @NotEmpty
+        String email
+) {
+}

--- a/src/main/resources/com/beyond/ticketLink/user/persistence/mapper/UserMapper.xml
+++ b/src/main/resources/com/beyond/ticketLink/user/persistence/mapper/UserMapper.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.beyond.ticketLink.user.persistence.mapper.UserMapper">
+    <insert id="save" keyColumn="userNo">
+        insert into tb_user(userNo, id, pw, name, email, useYn, roleNo)
+        values (GET_NO('tb_user'), #{id}, #{pw}, #{name}, #{email}, #{useYn}, #{roleNo})
+    </insert>
+
+    <select id="findUserById">
+        select u.userNo,
+               u.id,
+               u.pw,
+               u.name,
+               u.email,
+               u.useYn,
+               r.name as 'role'
+        from tb_user u
+                 inner join tb_role r on u.roleNo = r.roleNo
+        where u.id = #{id};
+    </select>
+</mapper>

--- a/src/main/resources/com/beyond/ticketLink/user/persistence/mapper/UserRoleMapper.xml
+++ b/src/main/resources/com/beyond/ticketLink/user/persistence/mapper/UserRoleMapper.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.beyond.ticketLink.user.persistence.mapper.UserRoleMapper">
+    <select id="findByRoleName" resultType="UserRole">
+        select roleNo, name
+        from tb_role
+        where name = #{name};
+    </select>
+</mapper>

--- a/src/test/java/com/beyond/ticketLink/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/beyond/ticketLink/user/application/service/UserServiceImplTest.java
@@ -1,0 +1,76 @@
+package com.beyond.ticketLink.user.application.service;
+
+import com.beyond.ticketLink.common.exception.MessageType;
+import com.beyond.ticketLink.common.exception.TicketLinkException;
+import com.beyond.ticketLink.user.ui.requestbody.UserCreateRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+class UserServiceImplTest {
+
+    @Autowired
+    UserService service;
+
+    private static final String DUMMY_USER_A_ID = "dummyUserA";
+    private static final String NOT_EXIST_USER_ID = "notExistUserId";
+
+    @Test
+    @DisplayName("유저 회원가입 테스트")
+    @Transactional
+    void register() {
+        // given
+        UserCreateRequest REQUEST_REGISTER =
+                new UserCreateRequest("testUserA", "testUserA", "testUserA", "testUserA@beyond.com");
+
+        UserCreateRequest REQUEST_REGISTER_DUPLICATE_ID =
+                new UserCreateRequest(DUMMY_USER_A_ID, "testUserA", "testUserA", "testUserA@beyond.com");
+        // when
+        service.register(REQUEST_REGISTER);
+        // then
+        assertThatThrownBy(() -> service.register(REQUEST_REGISTER_DUPLICATE_ID))
+                .isInstanceOf(TicketLinkException.class)
+                .hasMessage(MessageType.DUPLICATE_USER_ID.getMessage());
+    }
+
+    @Test
+    @DisplayName("아이디 중복확인 테스트")
+    void checkDuplicateUserId() {
+        // given
+
+        // when
+
+
+        // then
+        assertThatThrownBy(() -> service.throwErrorWithDuplicateId(DUMMY_USER_A_ID))
+                .isInstanceOf(TicketLinkException.class)
+                .hasMessage(MessageType.DUPLICATE_USER_ID.getMessage());
+
+        assertThatCode(() -> service.throwErrorWithDuplicateId(NOT_EXIST_USER_ID))
+                .doesNotThrowAnyException();
+
+    }
+
+    @Test
+    @DisplayName("아이디로 조회 테스트")
+    void loadUserByUsername() {
+        // given
+
+        // when
+        UserDetails DUMMY_USER_A = service.loadUserByUsername(DUMMY_USER_A_ID);
+        // then
+        assertThat(DUMMY_USER_A.getUsername()).isEqualTo(DUMMY_USER_A_ID);
+        assertThatThrownBy(() -> service.loadUserByUsername(NOT_EXIST_USER_ID))
+                .isInstanceOf(UsernameNotFoundException.class)
+                .hasMessage(MessageType.USER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/beyond/ticketLink/user/persistence/repository/UserRepositoryImplTest.java
+++ b/src/test/java/com/beyond/ticketLink/user/persistence/repository/UserRepositoryImplTest.java
@@ -1,0 +1,67 @@
+package com.beyond.ticketLink.user.persistence.repository;
+
+import com.beyond.ticketLink.user.application.domain.TicketLinkUserDetails;
+import com.beyond.ticketLink.user.persistence.dto.UserCreateDto;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+class UserRepositoryImplTest {
+
+    private static final char ENABLE_USER = 'Y';
+    private static final char DISABLE_USER = 'N';
+
+    private static final long ROLE_USER = 2L;
+    private static final long ROLE_ADMIN = 1L;
+
+    private static final String DUMMY_USER_A_ID = "dummyUserA";
+    private static final String NOT_EXIST_USER_ID = "notExist";
+
+
+
+    @Autowired
+    private UserRepository repository;
+
+    @Test
+    @DisplayName("아이디로 유저 찾기 테스트")
+    void findUserById() {
+        // given
+
+        // when
+        Optional<TicketLinkUserDetails> DUMMY_USER_A = repository.findUserById(DUMMY_USER_A_ID);
+        Optional<TicketLinkUserDetails> NOT_EXIST_USER = repository.findUserById(NOT_EXIST_USER_ID);
+        // then
+        assertThat(DUMMY_USER_A.isPresent()).isTrue();
+        assertThat(DUMMY_USER_A.get().getId()).isEqualTo(DUMMY_USER_A_ID);
+        assertThat(DUMMY_USER_A.get().getRole()).isEqualTo("관리자");
+
+        assertThat(NOT_EXIST_USER.isEmpty()).isTrue();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("유저 생성 테스트")
+    void save() {
+        // given
+        UserCreateDto USER_CREATE_COMMAND = UserCreateDto.builder()
+                .id("userA")
+                .pw("1234")
+                .email("testUserA@beyond.com")
+                .name("테스트유저1")
+                .useYn(ENABLE_USER)
+                .roleNo(ROLE_USER)
+                .build();
+        // when
+        repository.save(USER_CREATE_COMMAND);
+        // then
+    }
+}

--- a/src/test/java/com/beyond/ticketLink/user/persistence/repository/UserRoleRepositoryImplTest.java
+++ b/src/test/java/com/beyond/ticketLink/user/persistence/repository/UserRoleRepositoryImplTest.java
@@ -1,0 +1,42 @@
+package com.beyond.ticketLink.user.persistence.repository;
+
+import com.beyond.ticketLink.user.application.domain.UserRole;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserRoleRepositoryImplTest {
+
+    @Autowired
+    private UserRoleRepository repository;
+
+    public static final String ROLE_NAME_ADMIN = "관리자";
+    public static final String ROLE_NAME_USER = "일반사용자";
+    public static final String ROLE_NAME_NOT_EXIST = "ROLE_NAME_NOT_EXIST";
+
+    @Test
+    @DisplayName("유저 role 검색 테스트")
+    void findByRoleName() {
+        // given
+
+        // when
+        Optional<UserRole> roleAdmin = repository.findByRoleName(ROLE_NAME_ADMIN);
+        Optional<UserRole> roleUser = repository.findByRoleName(ROLE_NAME_USER);
+        Optional<UserRole> roleNotExist = repository.findByRoleName(ROLE_NAME_NOT_EXIST);
+        // then
+        assertThat(roleAdmin.isPresent()).isTrue();
+        assertThat(roleUser.isPresent()).isTrue();
+        assertThat(roleNotExist.isEmpty()).isTrue();
+
+        assertThat(roleAdmin.get().getName()).isEqualTo(ROLE_NAME_ADMIN);
+        assertThat(roleUser.get().getName()).isEqualTo(ROLE_NAME_USER);
+    }
+}


### PR DESCRIPTION
### 구현 기능
1. 회원가입
    - 이메일 인증 기능 미적용
2. 아이디로 회원 조회
3. 아이디 중복확인
   - 중복된 아이디일 경우 404 리턴